### PR TITLE
Esp32 support

### DIFF
--- a/arduino/ESP32.md
+++ b/arduino/ESP32.md
@@ -1,0 +1,32 @@
+# ESP32 Bubbler Bottle programming
+
+This is the programming guide if you choose to use an ESP32 instead of the (recommended) ItsyBitsy nRF52840 Express. For the ItsyBitsy, please [see the main readme](README.md).
+
+## Programming setup
+
+* Install the [Arduino IDE](https://www.arduino.cc/en/software) and [the Espressif ESP32 boards](https://espressif-docs.readthedocs-hosted.com/projects/arduino-esp32/en/latest/installing.html)
+* In the Arduino IDE, go to "Tools"->"Manage Libraries"
+* Search for, and install the following libraries:
+	- FastLED
+	- Adafruit NeoPixel
+	- NimBLE-Arduino
+	- Adafruit BMP280 Library
+
+## Programming
+* Select the board "Adafruit QT Py ESP32-C3"
+* Download the Bubbler code and upload it to the board. On the first run the code will store some defaults and reboot, so it will take a bit longer.
+* On startup the code will cause both the LEDs to light up white, then shortly after they'll turn pink then fade to red. Blowing hard around the sensor hole will cause them to turn pink and fade back to red again.
+
+Now you can connect to the board via bluetooth and set some defaults if you wish
+
+## Wifi Support
+
+You can enable wifi support by changing the `ENABLE_BLE` and `ENABLE_WIFI` defined inside `bubbler.ino`.
+
+Wifi support is quite rough at the moment; if you want to use it you should be familiar with Arduino programming and look at wifi.ino.
+
+To use Wifi, you need to install the following additional libraries using the library manager:
+* AsyncMQTT_Generic
+
+You also have to manually install the following library that is not available via the library manager:
+* https://github.com/me-no-dev/AsyncTCP

--- a/arduino/README.md
+++ b/arduino/README.md
@@ -1,5 +1,7 @@
 # Bubbler Bottle programming
 
+Note - there is a [separate Readme if you use an ESP32](ESP32.md).
+
 ## Programming setup
 
 * Install the arduino tool and board support. [Use this Adafruit guide](https://learn.adafruit.com/adafruit-itsybitsy-nrf52840-express/arduino-support-setup)
@@ -7,6 +9,7 @@
   * Search for "FastLED" and install it
   * Search for "BMP280" and install "Adafruit BMP280 Library"
   * Search for "spiflash" and install "Adafruit_SPIFlash"
+  * Search for "NeoPixel" and install "Adafruit NeoPixel"
 
 ## Programming first step
 

--- a/arduino/bubbler/.gitignore
+++ b/arduino/bubbler/.gitignore
@@ -1,0 +1,1 @@
+arduino_secrets.h

--- a/arduino/bubbler/airsensor.ino
+++ b/arduino/bubbler/airsensor.ino
@@ -3,10 +3,14 @@
 
 Adafruit_BMP280 bmp;
 
+// Track if we do have an airsensor. If no, just return a 0 for read, but otherwise work.
+// This lets us, e.e., debug BLE with just a board, even if it does not feature a sensor.
+bool have_airsensor = true;
+
 void airsensor_setup() {
   if (!bmp.begin(0x76, BMP280_CHIPID)) {
     Serial.println("Missing BMP280");
-    //while(1) yield();
+    return;
   }
   bmp.setSampling(Adafruit_BMP280::MODE_NORMAL,
                   Adafruit_BMP280::SAMPLING_NONE, /* No temperature */
@@ -16,5 +20,8 @@ void airsensor_setup() {
 }
 
 int airsensor_read() {
+  if ( ! have_airsensor )
+    return 0;
+
   return bmp.readPressure();
 }

--- a/arduino/bubbler/airsensor.ino
+++ b/arduino/bubbler/airsensor.ino
@@ -10,8 +10,10 @@ bool have_airsensor = true;
 void airsensor_setup() {
   if (!bmp.begin(0x76, BMP280_CHIPID)) {
     Serial.println("Missing BMP280");
+    have_airsensor = false;
     return;
   }
+
   bmp.setSampling(Adafruit_BMP280::MODE_NORMAL,
                   Adafruit_BMP280::SAMPLING_NONE, /* No temperature */
                   Adafruit_BMP280::SAMPLING_X1, /* Pressure, no oversampling */

--- a/arduino/bubbler/bubbler.ino
+++ b/arduino/bubbler/bubbler.ino
@@ -158,7 +158,7 @@ void check_breath() {
     blow_state = 1;
     fade = 0;
     // fade, but slow while the breath is happening
-    //comms_send_breath(true);
+    comms_send_breath(true);
 #ifdef ESP32
 #ifdef ENABLE_WIFI
     wifi_send_breath(true);
@@ -169,7 +169,7 @@ void check_breath() {
     colorWas = colorStart;
   } else if (blow_state == 1 && pread > avg) {
     blow_state = 0;
-    //comms_send_breath(false);
+    comms_send_breath(false);
 #ifdef ESP32
 #ifdef ENABLE_WIFI
     wifi_send_breath(false);
@@ -181,7 +181,6 @@ void check_breath() {
   //if (debug_mode & 1) comms_uart_send_graph(pread, avg);
   //Serial.printf("%d,%d,%d\n",pread,avg,avg-avthres);
   avg = (avg * 8 + pread * 2) / 10;
-
 }
 
 void debug_checkcodespeed() {
@@ -296,9 +295,7 @@ void main_loop() {
   debug_checkcodespeed();
   check_breath();
 #ifdef ENABLE_BLE
-#ifndef ESP32
   comms_check_distance(DISTANCE_TO_SYNC_LEDS);
-#endif /* ESP32 */
   look_for_close_bottles();
 #endif /* ENABLE_BLE */
   leds_do_fade();

--- a/arduino/bubbler/bubbler.ino
+++ b/arduino/bubbler/bubbler.ino
@@ -41,7 +41,7 @@
 #include <Adafruit_NeoPixel.h>
 
 #ifdef ESP32
-#include "BLEDevice.h"
+#include "NimBLEDevice.h"
 #ifdef ENABLE_WIFI
 #include <WiFi.h>
 #include <AsyncMqtt_Generic.h>

--- a/arduino/bubbler/bubbler.ino
+++ b/arduino/bubbler/bubbler.ino
@@ -43,7 +43,7 @@
 #define ENABLE_BLE /* uncomment to enable BLE communications */
 // #define ENABLE_WIFI /* uncomment to enable WIFI communications, only ESP32 */
 
-#define PIXEL_TYPE NEO_GRBW + NEO_KHZ800 /* The Pixel type that you have, defined as per Adafruit neopixel library. You might have to change, e.g. the color order */
+#define PIXEL_TYPE NEO_GRB + NEO_KHZ800 /* The Pixel type that you have, defined as per Adafruit neopixel library. You might have to change, e.g. the color order */
 
 #define MAX_BOTTLES 16 /* Maximum bottles supported for BLE communication */
 #define NUM_LEDS 2 /* Number of LEDS - this is two, unless you change the hardware */
@@ -280,11 +280,9 @@ void setup() {
   comms_init(bottle_number);
 #endif
   Serial.printf("I am bottle number %d\n", bottle_number);
-#ifdef ESP32
   xTaskCreate(TaskMain, "Main", 10000, nullptr, 1, nullptr);
-#ifdef ENABLE_BLE
+#if defined(ENABLE_BLE) && defined(ESP32)
   xTaskCreate(TaskScan, "Scan", 10000, nullptr, 2, nullptr);
-#endif
 #endif
 }
 
@@ -302,11 +300,6 @@ void main_loop() {
   delay(100);
 }
 
-#ifndef ESP32
-void loop() {
-  main_loop();
-}
-#else
 void loop() {
 }
 
@@ -324,6 +317,3 @@ void TaskScan(void *pvParameters) {
   }
 }
 #endif
-
-#endif
-

--- a/arduino/bubbler/bubbler.ino
+++ b/arduino/bubbler/bubbler.ino
@@ -41,8 +41,10 @@
 #include <Adafruit_NeoPixel.h>
 
 #ifdef ESP32
+#ifdef ENABLE_WIFI
 #include <WiFi.h>
 #include <AsyncMqtt_Generic.h>
+#endif
 #endif
 
 #ifndef ESP32
@@ -96,7 +98,7 @@ short debug_mode = 0;
 void leds_setup() {
   // "Boot" mode
   px.begin();
-  px.setBrightness(255);
+  px.setBrightness(70);
   px.setPixelColor(0, 255, 255, 255);
   px.setPixelColor(1, 255, 255, 255);
   px.show();
@@ -146,14 +148,22 @@ void check_breath() {
     fade = 0;
     // fade, but slow while the breath is happening
     //comms_send_breath(true);
+#ifdef ESP32
+#ifdef ENABLE_WIFI
     wifi_send_breath(true);
+#endif
+#endif
     fadespeed = 4;
     colorCurrent = colorStart;
     colorWas = colorStart;
   } else if (blow_state == 1 && pread > avg) {
     blow_state = 0;
     //comms_send_breath(false);
+#ifdef ESP32
+#ifdef ENABLE_WIFI
     wifi_send_breath(false);
+#endif
+#endif
     // fade back faster now the breath has 'stopped'
     fadespeed = 16;
   }
@@ -233,7 +243,6 @@ void look_for_close_bottles() {
 
 */
 
-/*
 void bottle_setup() {
   // MAX_BOTTLES green bottles, sitting on a wall...
   for (short i = 0; i < MAX_BOTTLES; i++) {
@@ -241,27 +250,30 @@ void bottle_setup() {
     seen_bottles[i].changed_state = false;
   }
 }
-*/
 
 // Main Entry Points are Below
 
 void setup() {
   Serial.begin(115200);
-  //bottle_setup();
+  bottle_setup();
   leds_setup();
   delay(1500);
   airsensor_setup();
   avg = airsensor_read();
   storage_setup();
+#ifdef ESP32
+#ifdef ENABLE_WIFI
   wifi_setup();
+#endif
+#endif
   leds_startingstate();
   comms_init(bottle_number);
   Serial.printf("I am bottle number %d\n", bottle_number);
 }
 
 void loop() {
-  //comms_uart_colorpicker();
-  //debug_checkcodespeed();
+  comms_uart_colorpicker();
+  debug_checkcodespeed();
   check_breath();
   //comms_check_distance(DISTANCE_TO_SYNC_LEDS);
   //look_for_close_bottles();

--- a/arduino/bubbler/comms.ino
+++ b/arduino/bubbler/comms.ino
@@ -1,3 +1,5 @@
+#ifndef ESP32
+
 BLEUart bleuart;
 #include "coyote.h"
 
@@ -234,3 +236,11 @@ void btAndSerialPrintf(const char* format, ...) {
 
   delete(buffer);
 }
+
+#else
+
+void comms_init(short myid) {
+//  BLE.begin();
+}
+
+#endif

--- a/arduino/bubbler/comms.ino
+++ b/arduino/bubbler/comms.ino
@@ -279,8 +279,6 @@ void comms_uart_colorpicker(void) {
   if (!bt && Serial.available()<1)
     return;
 
-  Serial.println("Got something");
-
   int command = bt?bluetooth_read():Serial.read();
   if (command != '!')
      return;

--- a/arduino/bubbler/comms.ino
+++ b/arduino/bubbler/comms.ino
@@ -1,3 +1,6 @@
+// BLE implementation. This file has the Itsy Bitsy implementation first, followed
+// by the ESP32 implementation, followed by the architecture-independent methods.
+
 #ifdef ENABLE_BLE
 
 // https://www.bluetooth.com/specifications/assigned-numbers/company-identifiers steal a name nothing over 0x1000 is used anyway
@@ -170,9 +173,7 @@ void comms_init(short myid) {
 void scan_loop() {
   if ( !coyote_connected ) {
     NimBLEScanResults foundDevices = pBLEScan->start(scanTime, false);
-    Serial.print("Devices found: ");
-    Serial.println(foundDevices.getCount());
-    Serial.println("Scan done!");
+
     pBLEScan->clearResults();   // delete results fromBLEScan buffer to release memory
     delay(2000);
 
@@ -258,7 +259,6 @@ int bluetooth_read() {
   return bleuart.read();
 #else
   auto data = callbacks.get_char();
-  Serial.printf("Got: %c\n", data);
   return data;
 #endif
 }

--- a/arduino/bubbler/coyote.ino
+++ b/arduino/bubbler/coyote.ino
@@ -12,8 +12,6 @@ uint8_t BATTERY_CHAR_UUID[] = {0xad, 0xe8, 0xf3, 0xd4, 0xb8, 0x84, 0x94, 0xa0, 0
 
 #ifdef ESP32
 
-#include "BLEDevice.h"
-
 static BLEUUID COYOTE_SERVICE_BLEUUID(COYOTE_SERVICE_UUID, 16, false);
 static BLEUUID CONFIG_CHAR_BLEUUID(CONFIG_CHAR_UUID, 16, false);
 static BLEUUID POWER_CHAR_BLEUUID(POWER_CHAR_UUID, 16, false);
@@ -41,7 +39,7 @@ static void bubbler_notify_callback(
   size_t length,
   bool isNotify) {
     Serial.print("Notify callback for characteristic ");
-    Serial.print(pBLERemoteCharacteristic->getUUID().toString().c_str());
+    Serial.print(pBLERemoteCharacteristic->getUUID().toString().c_str());    
     Serial.print(" of data length ");
     Serial.println(length);
     Serial.print("data: ");
@@ -50,8 +48,8 @@ static void bubbler_notify_callback(
 
 void coyote_setup(void) {
   Serial.println("Creating BLE client");
-
-
+  Serial.printf("Looking for service %s\n", COYOTE_SERVICE_BLEUUID.toString().c_str());
+  Serial.printf("Looking for char %s\n", CONFIG_CHAR_BLEUUID.toString().c_str());
 }
 
 bool connect_to_coyote(BLEAdvertisedDevice* coyote_device) {

--- a/arduino/bubbler/coyote.ino
+++ b/arduino/bubbler/coyote.ino
@@ -1,3 +1,5 @@
+#ifdef ENABLE_BLE
+
 // References:
 // https://rezreal.github.io/coyote/web-bluetooth-example.html
 // https://github.com/OpenDGLab/OpenDGLab-Connect/blob/master/src/services/DGLab.js
@@ -331,4 +333,5 @@ void central_connect_callback(uint16_t conn_handle) {
   Serial.println("coyote connected!");
 }
 
-#endif
+#endif /* not ESP32 */
+#endif /* ENABLE_BLE */

--- a/arduino/bubbler/coyote.ino
+++ b/arduino/bubbler/coyote.ino
@@ -14,29 +14,29 @@ uint8_t BATTERY_CHAR_UUID[] = {0xad, 0xe8, 0xf3, 0xd4, 0xb8, 0x84, 0x94, 0xa0, 0
 
 #ifdef ESP32
 
-static BLEUUID COYOTE_SERVICE_BLEUUID(COYOTE_SERVICE_UUID, 16, false);
-static BLEUUID CONFIG_CHAR_BLEUUID(CONFIG_CHAR_UUID, 16, false);
-static BLEUUID POWER_CHAR_BLEUUID(POWER_CHAR_UUID, 16, false);
-static BLEUUID A_CHAR_BLEUUID(A_CHAR_UUID, 16, false);
-static BLEUUID B_CHAR_BLEUUID(B_CHAR_UUID, 16, false);
-static BLEUUID BATTERY_BLEUUID(BATTERY_UUID, 16, false);
-static BLEUUID BATTERY_CHAR_BLEUUID(BATTERY_CHAR_UUID, 16, false);
+static NimBLEUUID COYOTE_SERVICE_BLEUUID(COYOTE_SERVICE_UUID, 16, false);
+static NimBLEUUID CONFIG_CHAR_BLEUUID(CONFIG_CHAR_UUID, 16, false);
+static NimBLEUUID POWER_CHAR_BLEUUID(POWER_CHAR_UUID, 16, false);
+static NimBLEUUID A_CHAR_BLEUUID(A_CHAR_UUID, 16, false);
+static NimBLEUUID B_CHAR_BLEUUID(B_CHAR_UUID, 16, false);
+static NimBLEUUID BATTERY_BLEUUID(BATTERY_UUID, 16, false);
+static NimBLEUUID BATTERY_CHAR_BLEUUID(BATTERY_CHAR_UUID, 16, false);
 
-BLEClient* pClient;
+NimBLEClient* pClient;
 
-class BubblerClientCallback : public BLEClientCallbacks {
-  void onConnect(BLEClient* pclient) {
+class BubblerClientCallback : public NimBLEClientCallbacks {
+  void onConnect(NimBLEClient* pclient) {
     Serial.println("Client onConnect");
   }
 
-  void onDisconnect(BLEClient* pclient) {
+  void onDisconnect(NimBLEClient* pclient) {
     client_connected = false;
     Serial.println("Client onDisconnect");
   }
 };
 
 static void bubbler_notify_callback(
-  BLERemoteCharacteristic* pBLERemoteCharacteristic,
+  NimBLERemoteCharacteristic* pBLERemoteCharacteristic,
   uint8_t* pData,
   size_t length,
   bool isNotify) {
@@ -54,10 +54,10 @@ void coyote_setup(void) {
   Serial.printf("Looking for char %s\n", CONFIG_CHAR_BLEUUID.toString().c_str());
 }
 
-bool connect_to_coyote(BLEAdvertisedDevice* coyote_device) {
-  static BLERemoteCharacteristic* pRemoteCharacteristic;
+bool connect_to_coyote(NimBLEAdvertisedDevice* coyote_device) {
+  static NimBLERemoteCharacteristic* pRemoteCharacteristic;
 
-  pClient = BLEDevice::createClient();
+  pClient = NimBLEDevice::createClient();
   pClient->setClientCallbacks(new BubblerClientCallback());
 
   if ( client_connected )
@@ -83,7 +83,7 @@ bool connect_to_coyote(BLEAdvertisedDevice* coyote_device) {
   Serial.println("Done");
 */
 
-  BLERemoteService* pRemoteService = pClient->getService(COYOTE_SERVICE_BLEUUID);
+  NimBLERemoteService* pRemoteService = pClient->getService(COYOTE_SERVICE_BLEUUID);
   if (pRemoteService == nullptr) {
     Serial.print("Failed to find our service UUID: ");
     Serial.println(COYOTE_SERVICE_BLEUUID.toString().c_str());

--- a/arduino/bubbler/coyote.ino
+++ b/arduino/bubbler/coyote.ino
@@ -1,3 +1,5 @@
+#ifndef ESP32
+
 // References:
 // https://rezreal.github.io/coyote/web-bluetooth-example.html
 // https://github.com/OpenDGLab/OpenDGLab-Connect/blob/master/src/services/DGLab.js
@@ -217,3 +219,5 @@ void central_connect_callback(uint16_t conn_handle) {
 
   Serial.println("coyote connected!");
 }
+
+#endif

--- a/arduino/bubbler/storage.ino
+++ b/arduino/bubbler/storage.ino
@@ -51,8 +51,21 @@ void storage_setup() {
 
 #else
 
+// on ESP32 we use LittleFS
+
 #include <Arduino.h>
 #include "FS.h"
 #include <LittleFS.h>
+
+#define FORMAT_LITTLEFS_IF_FAILED true
+
+void storage_setup() {
+  if(!LittleFS.begin(FORMAT_LITTLEFS_IF_FAILED)){
+    Serial.println("LittleFS Mount Failed");
+    return;
+  }
+  Serial.println("LittleFS Mount Succeeded");
+  LittleFS.end();
+}
 
 #endif

--- a/arduino/bubbler/storage.ino
+++ b/arduino/bubbler/storage.ino
@@ -1,3 +1,5 @@
+#ifndef ESP32
+
 // No EEPROM.h on the itsybitsy so instead use SPI flash and store stuff in a file
 
 #include <SPI.h>
@@ -46,3 +48,11 @@ void storage_setup() {
     NVIC_SystemReset();
   }
 }
+
+#else
+
+#include <Arduino.h>
+#include "FS.h"
+#include <LittleFS.h>
+
+#endif

--- a/arduino/bubbler/storage.ino
+++ b/arduino/bubbler/storage.ino
@@ -1,3 +1,6 @@
+// Storage has two separate implementations for the Itsy Bitsy and for the ESP32
+// On the Itsy Bitsy, we use a FAT filesystem, on the ESP32 we use LittleFS.
+
 #ifndef ESP32
 
 // No EEPROM.h on the itsybitsy so instead use SPI flash and store stuff in a file

--- a/arduino/bubbler/wifi.ino
+++ b/arduino/bubbler/wifi.ino
@@ -1,0 +1,111 @@
+#ifdef ESP32
+
+#include <WiFi.h>
+#include <WiFiMulti.h>
+#include <AsyncMqtt_Generic.h>
+
+#include "arduino_secrets.h"
+
+// Todo - let these be configureable some other way besides editing the source
+// SSID and PW for your Router
+const String Router_SSID = SECRET_SSID;
+const String Router_Pass = SECRET_PASS;
+
+// Your MQTT settings.
+const String MQTT_HOST = SECRET_MQTT_HOST;
+const int MQTT_PORT = SECRET_MQTT_PORT;
+const String MQTT_USER = SECRET_MQTT_USER;
+const String MQTT_PASS = SECRET_MQTT_PASS;
+const String PubTopic = "bubbler/" + String(ESP.getEfuseMac(), HEX);
+
+// Send WLED commands to light up LED with the same colors?
+bool mqttSendWledCommands = true;
+const String wledTopic = "wled/all/api";
+
+WiFiMulti wimu;
+AsyncMqttClient mqttClient;
+
+void WiFiEvent(WiFiEvent_t event) {
+  switch ( event ) {
+    case ARDUINO_EVENT_WIFI_READY:
+      Serial.println("WiFi is ready");
+      break;
+     case ARDUINO_EVENT_WIFI_STA_CONNECTED:
+      Serial.println("Connected to base station");
+      break;
+     case ARDUINO_EVENT_WIFI_STA_GOT_IP6:
+     case ARDUINO_EVENT_WIFI_STA_GOT_IP:
+      Serial.print("WiFi connection established, local IP: ");
+      Serial.println(WiFi.localIP());
+      Serial.println("Connecting to MQTT...");
+      mqttClient.connect();
+      break;
+     case ARDUINO_EVENT_WIFI_STA_LOST_IP:
+      Serial.println("WiFi lost IP");
+      break;
+     case ARDUINO_EVENT_WIFI_STA_DISCONNECTED:
+      Serial.println("WiFi lost connection to base");
+  }
+}
+
+void onMqttConnect(bool sessionPresent)
+{
+  static char buf[8];
+  Serial.print("Connected to MQTT broker: "); Serial.print(MQTT_HOST);
+  Serial.print(", port: "); Serial.println(MQTT_PORT);
+  Serial.print("PubTopic: "); Serial.println(PubTopic);
+  mqttClient.publish((PubTopic + "/status").c_str(), 0, false, "connected");
+  CRGB target = colorTarget;
+  CRGB start = colorStart;
+
+  snprintf(buf, 7, "%02X%02X%02X", start.r, start.g, start.b);
+  mqttClient.publish((PubTopic + "/startcolor").c_str(), 0, true, buf);
+  snprintf(buf, 7, "%02X%02X%02X", target.r, target.g, target.b);
+  mqttClient.publish((PubTopic + "/targetcolor").c_str(), 0, true, buf);
+}
+
+void onMqttDisconnect(AsyncMqttClientDisconnectReason reason)
+{
+  (void) reason;
+  Serial.println("Disconnected from MQTT.");
+}
+
+void wifi_send_breath(bool b) {
+  static char buf[100];
+  String out = "in";
+  if ( ! b )
+    out = "done";
+  mqttClient.publish((PubTopic + "/breath").c_str(), 0, false, out.c_str() );
+
+  if ( ! mqttSendWledCommands )
+    return;
+
+  if ( b ) {
+    CRGB start = colorStart;
+    snprintf(buf, 100, "{\"bri\": 255, \"tt\": 0, \"seg\":[{\"fx\":0,\"col\":[[%d,%d,%d]]}]}", start.r, start.g, start.b);
+    mqttClient.publish(wledTopic.c_str(), 0, false, buf);
+    // skip the slow transition for the moment. It interferes with the fast one afterwards.
+    //mqttClient.publish("wled/all/api", 0, false, "{\"bri\": 255, \"tt\": 64, \"seg\":[{\"col\":[[0,0,255]]}}" );
+  } else {
+    CRGB target = colorTarget;
+    snprintf(buf, 100, "{\"bri\": 255, \"tt\": 16, \"seg\":[{\"fx\":0,\"col\":[[%d,%d,%d]]}]}", target.r, target.g, target.b);
+    mqttClient.publish(wledTopic.c_str(), 0, false, buf);
+  }
+}
+
+void wifi_setup() {
+  Serial.println("Starting WiFi init");
+
+  wimu.addAP(Router_SSID.c_str(), Router_Pass.c_str());
+  Serial.printf("Trying to connect to %s with password %s\n", Router_SSID.c_str(), Router_Pass.c_str());
+
+  WiFi.onEvent(WiFiEvent);
+  mqttClient.onConnect(onMqttConnect);
+  mqttClient.onDisconnect(onMqttDisconnect);
+  mqttClient.setServer(MQTT_HOST.c_str(), MQTT_PORT);
+  mqttClient.setCredentials(MQTT_USER.c_str(), MQTT_PASS.c_str());
+
+  wimu.run();
+}
+
+#endif

--- a/arduino/bubbler/wifi.ino
+++ b/arduino/bubbler/wifi.ino
@@ -1,5 +1,12 @@
-#ifdef ESP32
 #ifdef ENABLE_WIFI
+
+#ifndef ESP32
+#error ESP32 required for wifi
+#endif
+
+#ifdef ENABLE_BLE
+#error BLE and WiFi cannot be used simultaneously
+#endif
 
 #include <WiFi.h>
 #include <WiFiMulti.h>
@@ -109,5 +116,4 @@ void wifi_setup() {
   wimu.run();
 }
 
-#endif
 #endif

--- a/arduino/bubbler/wifi.ino
+++ b/arduino/bubbler/wifi.ino
@@ -1,4 +1,5 @@
 #ifdef ESP32
+#ifdef ENABLE_WIFI
 
 #include <WiFi.h>
 #include <WiFiMulti.h>
@@ -108,4 +109,5 @@ void wifi_setup() {
   wimu.run();
 }
 
+#endif
 #endif

--- a/arduino/bubbler/wifi.ino
+++ b/arduino/bubbler/wifi.ino
@@ -1,3 +1,7 @@
+// Wifi only works on the ESP32. Note that this is pretty rough.
+// Also note - if you want to use wifi, you have to provide an arduino_secrets.h file
+// and provide the belowmentioned SECRET_* values.
+
 #ifdef ENABLE_WIFI
 
 #ifndef ESP32

--- a/electronics/ESP32.md
+++ b/electronics/ESP32.md
@@ -1,0 +1,13 @@
+# Using an ESP32 for the Bubbler
+
+Instead of the "Adafruit Itsy Bitsy NRF52480 Express", you also can use an ESP32, specifically an "Adafruit QT Py ESP32-C3" ([Adafruit (US)](https://www.adafruit.com/product/5405) / [Pimoroni (UK)](https://shop.pimoroni.com/products/adafruit-qt-py-esp32-c3-wifi-dev-board-with-stemma-qt?variant=39850337370195)).
+
+Note - it is possible that you can also use other ESP32 boards with the same form factor. However, we only tested this specific board.
+
+To use this board, use the [main construction manual](README.md) with the following changes:
+
+To solder the JST and the BMP280 boards to the ESP32, start with the GND wire, as you need to fit two wires into the same hole. The JST female red wire goes to the "5V" pin, the jst socket yellow wire goes to the "A0" PIN.
+
+Solder the other wires from the BCM280 board. VCC on the BMP280 goes to the "3V" pin, SDA goes to the "SDA" pin and SCL goes to the "SCL" pin.
+
+Since the Adafruit QT Py has a Stemma QT port, you can also solder the BMP280 to a 4-pin JST-ST/Stemma QT cable, and plug that cable into the Qt Py. Suitable cables are available at [Adafruit (US)](https://www.adafruit.com/product/4399) / [Pimorino (UK)](https://shop.pimoroni.com/products/jst-sh-cable-qwiic-stemma-qt-compatible?variant=31910609813587). You will probably have to get a cable with two JST-SH ports, and cut it apart.

--- a/electronics/README.md
+++ b/electronics/README.md
@@ -11,6 +11,8 @@
 | A tiny bit of double sided foam tape (or hotglue)||[Adafruit](https://www.adafruit.com/product/5019)|
 | one M2.5 5mm screw|any hardware store or ebay|
 
+Note that it is now possible to use an ESP32 instead of the Adafruit Itsy Bitsy; see this [separate readme](ESP32.md).
+
 ## Construction
 
 ### Step 1


### PR DESCRIPTION
This PR adds esp32 support to the project - specifically using the Adafruit QY Py ESP32-C3.

It still compiles with the original Itsy Bitsy with no functional changes. Furthermore, communication is compatible between the two device types.

I tried enhancing the configurability a bit - it is now easier to select the LED type one has. Furthermore, one can choose to disable/enable BLE with a define. For the ESP32, there also is initial wifi support.

When the implementations do not mesh super well (like for BLE communications), the files are now split into common parts, esp32-specific parts and itsy-bitsy specific parts.

Let me know what you think - I am happy to make changes.